### PR TITLE
feat: agrega workflow de GitHub Actions para ejecutar tests en emulador de Android (issue #16)

### DIFF
--- a/.github/workflows/android-emulator.yml
+++ b/.github/workflows/android-emulator.yml
@@ -1,0 +1,57 @@
+name: Android Emulator E2E Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Descargar APK de la Guinea Pig App
+        run: |
+          mkdir -p app
+          curl -L -o app/android.wdio.native.app.v1.0.8.apk https://github.com/webdriverio/native-demo-app/releases/download/v1.0.8/android.wdio.native.app.v1.0.8.apk
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up Android SDK
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: default
+          arch: x86_64
+          profile: pixel_3a
+          script: |
+            npm run wdio
+
+      - name: Upload Allure results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results
+          path: allure-results/
+
+      - name: Upload JUnit results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-results
+          path: junit-results/ 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 allure-results/
 allure-report/
 junit-results/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ Este comando ejecutará las pruebas utilizando WebdriverIO y generará un inform
 npm run open-report
 ```
 
+## Integración continua: Ejecución automática en emulador Android (GitHub Actions)
+
+Este proyecto incluye un workflow de GitHub Actions que automatiza la ejecución de las pruebas E2E en un emulador de Android. El workflow realiza lo siguiente:
+
+- Descarga la APK de ejemplo (Guinea Pig App) y la coloca en la carpeta `app/`.
+- Configura los permisos necesarios para el emulador en el runner de CI.
+- Levanta un emulador Android (API 34, Android 14) usando la acción `reactivecircus/android-emulator-runner`.
+- Instala las dependencias del proyecto (Node.js, Appium, WebdriverIO, etc).
+- Ejecuta los tests E2E definidos en el proyecto.
+- Publica los resultados de Allure y JUnit como artefactos del workflow.
+
+**¿Cuándo se ejecuta este workflow?**
+- Automáticamente en cada push o pull request sobre la rama `main`.
+
+Puedes consultar el archivo del workflow en `.github/workflows/android-emulator.yml` para más detalles.
+
 ## Contribuir
 
 ¡Siéntete libre de contribuir a este proyecto! Si encuentras errores o tienes ideas para mejorar el boilerplate, por favor abre un issue o envía una pull request.

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -62,11 +62,13 @@ export const config: Options.Testrunner = {
         // capabilities for local Appium web tests on an Android Emulator
         platformName: 'Android',
         'appium:deviceName': 'emulator-5554',
-        'appium:platformVersion': '16.0',
+        'appium:platformVersion': '14',
         'appium:automationName': 'UiAutomator2',
         'appium:appPackage': 'com.wdiodemoapp',
         'appium:appActivity': 'com.wdiodemoapp.MainActivity',
-        'appium:app': __dirname + '/app/android.wdio.native.app.v1.0.8.apk'
+        'appium:app': __dirname + '/app/android.wdio.native.app.v1.0.8.apk',
+        'appium:uiautomator2ServerInstallTimeout': 120000,
+        'appium:adbExecTimeout': 120000
     }],
 
     //


### PR DESCRIPTION
Este PR agrega un workflow de GitHub Actions que permite ejecutar los tests E2E en un emulador de Android, resolviendo el issue #16.

- Levanta un emulador Android usando la acción 'reactivecircus/android-emulator-runner'.
- Instala dependencias y ejecuta los tests con WebdriverIO/Appium.
- Publica los resultados de Allure y JUnit como artefactos.

Esto facilita la integración continua y la validación automática en dispositivos Android.